### PR TITLE
#6 Fix :  set loans as empty array when the last one is removed

### DIFF
--- a/Invent0ry/Forms/EditItemForm.xaml.cs
+++ b/Invent0ry/Forms/EditItemForm.xaml.cs
@@ -46,7 +46,12 @@ namespace Invent0ry.Forms
                 Item.Categories = CategoriesTextBox.Text.Split(new[] {categoriesSeparator}, StringSplitOptions.None).ToList();
             Item.Location = LocationTextBox.Text;
             if (!string.IsNullOrEmpty(LoansTextBox.Text))
-                Item.Loans = LoansTextBox.Text.Split(new[] {Environment.NewLine}, StringSplitOptions.None).ToList();
+            {
+                Item.Loans = LoansTextBox.Text.Split(new[] { Environment.NewLine }, StringSplitOptions.None).ToList();
+            } else
+            {
+                Item.Loans = new List<string>();
+            }
             DialogResult = true;
         }
 


### PR DESCRIPTION
The fix is simple, when the loans textbox is empty, the loans array is setted as empty